### PR TITLE
Force the list of repositories to be stored alphabetically

### DIFF
--- a/git-x.sh
+++ b/git-x.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-directories=($(find . -maxdepth 2 -type d -name .git ! -path ./.git | sed 's/\/\.git//' | sed 's/\.\///'))
+directories=($(find . -maxdepth 2 -type d -name .git ! -path ./.git | sed 's/\/\.git//' | sed 's/\.\///' | sort))
 parentGitRepository=`find . -maxdepth 1 -name .git`
 export arguments=$@
 


### PR DESCRIPTION
Using the previous script on Mac was already storing the repositories alphabetically.
But on Linux it was not. And this was causing difference in the `.gitrepositories` on projects with people using Mac and Linux.

This way the list of repositories is always stored alphabetically.
